### PR TITLE
Eliminate extra data copies

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
         // Canvas
         let displayZone = {
           ctx: undefined,       // canvas context
-          bmpArray: undefined,  // bitmap data
           imageData: undefined  // internal canvas bitmap data
         };
         // The following object maps the C Image structure
@@ -91,6 +90,7 @@
           // We get width and height from these informations
           image.width = Module.getValue(pImage + 0, 'i32');
           image.height = Module.getValue(pImage + 4, 'i32');
+          // console.log("Size wil be ", image.width, "x", image.height);
           // We known our WebAssembly code will not use anymore the allocated memory block.
           Module._free(srcBuf);
           // And we will not need the raw data anymore.
@@ -103,47 +103,33 @@
           canvas.height = image.height;
           document.getElementById('image-container').appendChild(canvas);
           displayZone.ctx = canvas.getContext('2d');
-          // The MSDN doc says Uint8ClampedArray but it does not work (colors are melted).
-          displayZone.bmpArray = new Uint8Array(image.width * image.height * 4).fill(0xff);
           displayZone.imageData = displayZone.ctx.createImageData(image.width, image.height);
         }
 
         function display() {
-          // Unfortunatly, bitmap pixels are RGB and canvas expects RGBA.
-          // So we have to convert pixel by pixel, and it is slow !
-          // The canvas Alpha is set in createDisplayZone() with fill(0xff)
-          // To improve performance, we should make the Web Assembly code
-          // do the pixel conversion into an allocated RGBA pixels space.
-          let len = image.width * image.height * 4;
-          for (let ptr = image.data, iDst = 0; iDst < len; ptr += 3, iDst += 4) {
-            displayZone.bmpArray[iDst + 0] = Module.getValue(ptr + 0, 'i8');
-            displayZone.bmpArray[iDst + 1] = Module.getValue(ptr + 1, 'i8');
-            displayZone.bmpArray[iDst + 2] = Module.getValue(ptr + 2, 'i8');
+          // It's a view, so we can write 32 bit at a time
+          let len = image.width * image.height
+          let buf32 = new Uint32Array(displayZone.imageData.data.buffer, 0, len)
+          // Alpha, opaque
+          let alpha = 0xff000000
+
+          // Copy directly from the module memory to imageData
+          // read from view of wasm image.data as Uint32 array
+          let source = new Uint32Array(Module.HEAP8.buffer, image.data, len)
+
+          // read 3 int, write 4 per loop, assumes len is a multiple of 4
+          for (let iSrc = 0, iDst = 0; iDst < len; iSrc += 3, iDst += 4) {
+              let bytes = source[iSrc];
+              buf32[iDst] = bytes | alpha;
+              let next = bytes >>> 24; // R
+              bytes = source[iSrc + 1]
+              buf32[iDst + 1] = next | ((bytes & 0xffff) << 8) | alpha;
+              next = bytes >>> 16; // GR
+              bytes = source[iSrc + 2]
+              buf32[iDst + 2] = next | ((bytes & 0xff)) << 16 | alpha;
+              buf32[iDst + 3] = (bytes >>> 8) | alpha;
           }
 
-          // Following is an aborted performance optimization.
-          // Problem comes from memory alignment : read RGB to write RGBA
-          // implies moving from 3 bytes to 3 bytes. When reading a i32 value with 
-          // getValue, we are unaligned. As the doc says, results may be
-          // unpredictable.
-          // To ensure alignment you add -s SAFE_HEAP=1 to your emcc, 
-          // the getValue will then crash.
-          //
-          // let buf32 = new Uint32Array(image.width * image.height * 4);
-          // let len = image.width * image.height;
-          // for (let ptr = image.data, iDst = 0; iDst < len; ptr += 4, iDst += 1) {
-          //     let bytes = Module.getValue(ptr, 'i32'); // = RGBR, BRxx, B000                        
-          //     let a = 255;
-          //     let r = (bytes & 0xff000000) >> 24;
-          //     let g = (bytes & 0x00ff0000) >> 16;
-          //     let b = (bytes & 0x0000ff00) >> 8;
-          //     // buf32 format : ABGR
-          //     buf32[iDst] = (a << 24) | (b << 16) | (g << 8) | r;
-          // }
-          // displayZone.bmpArray = new Uint8ClampedArray(buf32.buffer);
-
-          // We need these two calls to trigger the canvas update
-          displayZone.imageData.data.set(displayZone.bmpArray);
           displayZone.ctx.putImageData(displayZone.imageData, 0, 0);
         }
 

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
           // Copy directly from the module memory to imageData
           // read from view of wasm image.data as Uint32 array
-          let source = new Uint32Array(Module.HEAP8.buffer, image.data, len)
+          let source = new Uint32Array(Module.HEAP8.buffer, image.data, len / 4 * 3)
 
           // read 3 int, write 4 per loop, assumes len is a multiple of 4
           for (let iSrc = 0, iDst = 0; iDst < len; iSrc += 3, iDst += 4) {

--- a/index.html
+++ b/index.html
@@ -123,11 +123,11 @@
               buf32[iDst] = bytes | alpha;
               let next = bytes >>> 24; // R
               bytes = source[iSrc + 1]
-              buf32[iDst + 1] = next | ((bytes & 0xffff) << 8) | alpha;
+              buf32[iDst + 1] = next | bytes << 8 | alpha;
               next = bytes >>> 16; // GR
               bytes = source[iSrc + 2]
-              buf32[iDst + 2] = next | ((bytes & 0xff)) << 16 | alpha;
-              buf32[iDst + 3] = (bytes >>> 8) | alpha;
+              buf32[iDst + 2] = next | bytes << 16 | alpha;
+              buf32[iDst + 3] = bytes >>> 8 | alpha;
           }
 
           displayZone.ctx.putImageData(displayZone.imageData, 0, 0);

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 
           // Copy directly from the module memory to imageData
           // read from view of wasm image.data as Uint32 array
-          let source = new Uint32Array(Module.HEAP8.buffer, image.data, len / 4 * 3)
+          let source = new Uint32Array(Module.HEAP8.buffer, image.data, len * 3 / 4)
 
           // read 3 int, write 4 per loop, assumes len is a multiple of 4
           for (let iSrc = 0, iDst = 0; iDst < len; iSrc += 3, iDst += 4) {

--- a/webassembly-jpeg.c
+++ b/webassembly-jpeg.c
@@ -9,7 +9,7 @@ Image *pSrcImage;
 Image *EMSCRIPTEN_KEEPALIVE setSrcImage(BYTE *jpegData, ULONG size)
 {
     pSrcImage = readJpeg(jpegData, size);
-    EM_ASM({ console.log('setSrcImage done'); });
+    // EM_ASM({ console.log('setSrcImage done'); });
     return pSrcImage;
 }
 
@@ -23,7 +23,7 @@ Image *EMSCRIPTEN_KEEPALIVE compress(ULONG quality)
     free(pCompressedImage->data);
     free(pCompressedImage);
 
-    EM_ASM_({ console.log('compress with quality', $0, ' done'); }, quality);
+    // EM_ASM_({ console.log('compress with quality', $0, ' done'); }, quality);
 
     return pDecompressedImage;
 }


### PR DESCRIPTION
Hi @AntoineViau,

As others have said, thanks for this perfect little example.
I made it simpler and faster by avoiding extra copies of the image, transferring data directly from the wasm image buffer to the display image data, dealing with the 24 to 32 bit unaligned copies.